### PR TITLE
integrate MADR into stopcheck closes #20

### DIFF
--- a/main.py
+++ b/main.py
@@ -29,7 +29,7 @@ from datasets import load_dataset, Dataset, concatenate_datasets
 
 from src import config
 
-if __name__ == "__main__":
+def parse_arguments():
     parser = argparse.ArgumentParser(
         usage='%(prog)s [args] -- prog'
     )
@@ -52,14 +52,22 @@ if __name__ == "__main__":
     parser.add_argument('-l', '--log-trace',
                         help='Output a trace to the log file (define in config.py). Overrides --num-claims to 2.',
                         action='store_true')
+
     args = parser.parse_args()
 
+    # handle overrides
     if args.log_trace:
         config.make_logger()
         args.num_claims = 2
 
     if args.debate_stop:
         args.ragar = False
+
+    return args
+
+
+if __name__ == "__main__":
+    args = parse_arguments()
 
     fever_labels = ["REFUTES", "SUPPORTS", "NOT ENOUGH INFO"]
     ds = load_dataset("fever", "v1.0", trust_remote_code=True)

--- a/main.py
+++ b/main.py
@@ -46,6 +46,9 @@ if __name__ == "__main__":
                         metavar='',
                         type=int,
                         default=100)
+    parser.add_argument('--debate-stop',
+                        help='Refines the stop_check agent with MADR. Overrides -r.',
+                        action='store_true')
     parser.add_argument('-l', '--log-trace',
                         help='Output a trace to the log file (define in config.py). Overrides --num-claims to 2.',
                         action='store_true')
@@ -54,6 +57,9 @@ if __name__ == "__main__":
     if args.log_trace:
         config.make_logger()
         args.num_claims = 2
+
+    if args.debate_stop:
+        args.ragar = False
 
     fever_labels = ["REFUTES", "SUPPORTS", "NOT ENOUGH INFO"]
     ds = load_dataset("fever", "v1.0", trust_remote_code=True)
@@ -74,7 +80,7 @@ if __name__ == "__main__":
 
     # Setup CoRAG system here
     mc = LlamaCppClient(prompts_dir, think_mode_bool=args.think)
-    corag = RagarCorag(mc)
+    corag = RagarCorag(mc, args.debate_stop)
 
     labels = []
     preds = []

--- a/src/madr.py
+++ b/src/madr.py
@@ -1,3 +1,18 @@
+"""
+Copyright:
+
+  Copyright © 2025 Eric
+
+  You should have received a copy of the MIT license along with this file.
+  If not, see https://mit-license.org/
+
+Commentary:
+
+  This file contains the MADR debate agent run-loop.
+
+Code:
+"""
+
 from .model_clients import ModelClient
 from .parsers import parse_boolean
 from . import config
@@ -9,11 +24,11 @@ def run_madr(mc: ModelClient, claim: str, qa_pairs: list[tuple[str, str]], expla
 
     for i in range(max_iters):
         config.LOGGER and config.LOGGER.info(f"Beginning MADR round {i}")
-    
+
         judgement =  mc.send_prompt("madr_judge", [f1, f2])
         if parse_boolean(judgement):
             break
-        
+
         if i != max_iters - 1:
             f1 = mc.send_prompt("madr_cross_fb", [f1, f2])
             f2 = mc.send_prompt("madr_cross_fb", [f2, f1])

--- a/src/parsers.py
+++ b/src/parsers.py
@@ -1,3 +1,19 @@
+"""
+Copyright:
+
+  Copyright © 2025 Eric
+  Copyright © 2025 bdunahu
+
+  You should have received a copy of the MIT license along with this file.
+  If not, see https://mit-license.org/
+
+Commentary:
+
+  This file contains various utility AI-response parsers.
+
+Code:
+"""
+
 def parse_boolean(text: str) -> bool:
     lower = text.lower()
     has_true = "true" in lower

--- a/src/ragar_corag.py
+++ b/src/ragar_corag.py
@@ -16,18 +16,21 @@ Code:
 
 from .corag import Corag
 from .model_clients import ModelClient
-from .config import INDEX_DIR
+from . import config
 from pyserini.search.lucene import LuceneSearcher
 from .parsers import parse_ternary, parse_conclusive
+from .madr import run_madr
 
 class RagarCorag(Corag):
     _mc: ModelClient
     _searcher: LuceneSearcher
+    _debate_stop: bool
 
-    def __init__(self, mc: ModelClient):
+    def __init__(self, mc: ModelClient, debate_stop: bool):
         super().__init__()
         self._mc = mc
-        self._searcher = LuceneSearcher(str(INDEX_DIR)) 
+        self._debate_stop = debate_stop
+        self._searcher = LuceneSearcher(str(config.INDEX_DIR))
         self._searcher.set_bm25(1.2, 0.75)
 
     def init_question(self, claim: str) -> str:
@@ -48,8 +51,20 @@ class RagarCorag(Corag):
         return self._mc.send_prompt("next_question", [claim, qa_pairs]).strip()
 
     def stop_check(self, claim: str, qa_pairs: list[tuple[str, str]]) -> bool:
-        res = self._mc.send_prompt("stop_check", [claim, qa_pairs]).lower()
-        return parse_conclusive(res)
+        exp = self._mc.send_prompt("stop_check", [claim, qa_pairs])
+        exp_bool = parse_conclusive(exp)
+
+        if not self._debate_stop:
+            return exp_bool
+
+        exp_bool_refined = parse_conclusive(
+            run_madr(self._mc, claim, qa_pairs, exp)
+        )
+
+        if exp_bool != exp_bool_refined:
+            config.LOGGER and config.LOGGER.info(f"MADR swapped to {exp_bool_refined}")
+
+        return exp_bool_refined
 
     def verdict(self, claim: str, qa_pairs: list[tuple[str, str]]) -> tuple[int, str | None]:
         res = self._mc.send_prompt("verdict", [claim, qa_pairs])

--- a/tests/test_corag.py
+++ b/tests/test_corag.py
@@ -37,7 +37,7 @@ class TestCorag(unittest.TestCase):
         prompts_dir = PROMPTS_DIR / "ragar"
 
         self.ragar_client = MockModelClient(prompts_dir)
-        self.ragar = RagarCorag(self.ragar_client)
+        self.ragar = RagarCorag(self.ragar_client, False)
 
     @classmethod
     def get_expected_prompts(self, client: MockModelClient,


### PR DESCRIPTION
Adds a new CLI flag which turns on MADR in the `stop_check` only. I've attached the relevant logs, but you can also verify with `--debate-stop` (automatically uses custom prompts).

[relevant.txt](https://github.com/user-attachments/files/23693070/relevant.txt)
