### PR TITLE
Use logger.disabled to control logging

### DIFF
--- a/main.py
+++ b/main.py
@@ -57,8 +57,11 @@ def parse_arguments():
 
     # handle overrides
     if args.log_trace:
-        config.make_logger()
         args.num_claims = 2
+        config.make_log_file()
+        config.LOGGER.disabled = False
+        config.LOGGER.info("\n" + "═" * 40)
+        config.LOGGER.info("Starting pipeline...")
 
     if args.debate_stop:
         args.ragar = False
@@ -80,10 +83,10 @@ if __name__ == "__main__":
     split = concatenate_datasets([supports, refutes])
 
     if args.ragar:
-        config.LOGGER and config.LOGGER.info("Using RAGAR prompts.")
+        config.LOGGER.info("Using RAGAR prompts.")
         prompts_dir = config.PROMPTS_DIR / "ragar"
     else:
-        config.LOGGER and config.LOGGER.info("Using CUSTOM prompts.")
+        config.LOGGER.info("Using CUSTOM prompts.")
         prompts_dir = config.PROMPTS_DIR / "custom"
 
     # Setup CoRAG system here

--- a/src/config.py
+++ b/src/config.py
@@ -35,20 +35,18 @@ SYSTEM_TAG = "<<SYSTEM>>"
 USER_TAG = "<<USER>>"
 
 # global logger
-LOGGER = None
+LOGGER = logging.getLogger('corag_logger')
+LOGGER.setLevel(logging.DEBUG)
+LOGGER.propagate = False
+LOGGER.disabled = True
 
-def make_logger():
+def make_log_file():
     if not os.path.exists(TRACE_PATH):
         with open(TRACE_PATH, 'w') as file:
             pass
-    global LOGGER
-    LOGGER = logging.getLogger('corag_logger')
-    LOGGER.setLevel(logging.DEBUG)
-    LOGGER.propagate = False
+
     file_handler = logging.FileHandler(TRACE_PATH)
     file_handler.setLevel(logging.DEBUG)
     formatter = logging.Formatter('%(asctime)s - %(levelname)s --- %(message)s')
     file_handler.setFormatter(formatter)
     LOGGER.addHandler(file_handler)
-    LOGGER.info("\n" + "═" * 40)
-    LOGGER.info("Starting pipeline...")

--- a/src/corag.py
+++ b/src/corag.py
@@ -45,13 +45,13 @@ class Corag(ABC):
         question = self.init_question(claim)
 
         for i in range(max_iters):
-            config.LOGGER and config.LOGGER.info(f"\n{'─' * 20}\nStarting iteration {i+1}")
+            config.LOGGER.info(f"\n{'─' * 20}\nStarting iteration {i+1}")
             if i > 0:
                 question = self.next_question(claim, qa_pairs)
             answer = self.answer(question)
             qa_pairs.append((question, answer))
             if self.stop_check(claim, qa_pairs):
-                config.LOGGER and config.LOGGER.info(f"\n{'─' * 20}\nBreaking at {i+1}")
+                config.LOGGER.info(f"\n{'─' * 20}\nBreaking at {i+1}")
                 break
 
         verdict, raw = self.verdict(claim, qa_pairs)

--- a/src/madr.py
+++ b/src/madr.py
@@ -18,12 +18,12 @@ from .parsers import parse_boolean
 from . import config
 
 def run_madr(mc: ModelClient, claim: str, qa_pairs: list[tuple[str, str]], explanation: str, max_iters: int = 3):
-    config.LOGGER and config.LOGGER.info(f"\n{'-' * 20}\nStarting MADR routine")
+    config.LOGGER.info(f"\n{'-' * 20}\nStarting MADR routine")
     f1 = mc.send_prompt("madr_init_fb1", [claim, qa_pairs, explanation])
     f2 = mc.send_prompt("madr_init_fb2", [claim, qa_pairs, explanation])
 
     for i in range(max_iters):
-        config.LOGGER and config.LOGGER.info(f"Beginning MADR round {i}")
+        config.LOGGER.info(f"Beginning MADR round {i}")
 
         judgement =  mc.send_prompt("madr_judge", [f1, f2])
         if parse_boolean(judgement):
@@ -34,5 +34,5 @@ def run_madr(mc: ModelClient, claim: str, qa_pairs: list[tuple[str, str]], expla
             f2 = mc.send_prompt("madr_cross_fb", [f2, f1])
 
     revised_verdict = mc.send_prompt("madr_revise", [f1, f2, explanation])
-    config.LOGGER and config.LOGGER.info(f"Ending MADR routine\n{'-' * 20}\n")
+    config.LOGGER.info(f"Ending MADR routine\n{'-' * 20}\n")
     return revised_verdict

--- a/src/ragar_corag.py
+++ b/src/ragar_corag.py
@@ -62,7 +62,7 @@ class RagarCorag(Corag):
         )
 
         if exp_bool != exp_bool_refined:
-            config.LOGGER and config.LOGGER.info(f"MADR swapped to {exp_bool_refined}")
+            config.LOGGER.info(f"MADR swapped to {exp_bool_refined}")
 
         return exp_bool_refined
 


### PR DESCRIPTION
This removes the need to have a `config.LOGGER and` check every time we want to call the logger. Only downside I see is that we'll need to evaluate the string passed to the logger even when its disabled, but I highly doubt this is a performance issue. 