### PR TITLE
Add a demonstration REPL.

### DIFF
--- a/main.py
+++ b/main.py
@@ -62,10 +62,10 @@ def parse_arguments():
                         help='Use the original MADR prompts. This option does nothing without including --debate-stop or --debate-verdict.',
                         action='store_true')
     parser.add_argument('-n', '--num-claims',
-                        help='The number of claims to process.',
+                        help='Turns on benchmarking mode and runs a number of claims equal to the argument.',
                         metavar='',
                         type=int,
-                        default=100)
+                        default=-1)
     parser.add_argument('--reranker',
                         help='Enable reranking after BM25 retrieval.',
                         action='store_true')
@@ -100,37 +100,11 @@ def setup_fever(num_claims: int):
     refutes = split.filter(lambda row: row["label"] == "REFUTES").select(range(half))
     return concatenate_datasets([supports, refutes])
 
-if __name__ == "__main__":
-    args = parse_arguments()
-    # load these later to enable fast --help and --version
-    from reranker import E2RankReranker, CrossEncoderReranker
-    from src.ragar_corag import RagarCorag
-
-    ragar_dir = config.RAGAR_DIR
-    madr_dir = config.MADR_DIR
-    if args.ragar_orig:
-        ragar_dir = config.RAGAR_ORIG_DIR
-        config.LOGGER.info("Using original RAGAR prompts.")
-    if args.madr_orig:
-        madr_dir = config.MADR_ORIG_DIR
-        config.LOGGER.info("Using original MADR prompts.")
-    prompt_files = get_prompt_files(ragar_dir, madr_dir)
-
-    reranker = None
-    if args.reranker:
-        try:
-            reranker = CrossEncoderReranker()
-        except (OSError, FileNotFoundError) as e:
-            print(f"ERROR: Model files not found or download failed: {e}")
-            reranker = None
-
+def benchmark(mc, corag, args):
     fever_labels = {0: "REFUTES", 1: "SUPPORTS", 2: "NOT ENOUGH INFO", 3: "NONE"}
     fever_split = setup_fever(args.num_claims)
 
     # Setup CoRAG system here
-    mc = LlamaCppClient(prompt_files, think_mode_bool=args.think)
-    corag = RagarCorag(mc, args.debate_stop, args.debate_verdict, reranker=reranker)
-
     # Run pipeline on claims
     golds = []
     outputs = []
@@ -172,3 +146,36 @@ if __name__ == "__main__":
         with open(to_write, "w") as file:
             json.dump(metrics, file, indent=4)
         print(f"Wrote {to_write}.")
+
+
+if __name__ == "__main__":
+    args = parse_arguments()
+    # load these later to enable fast --help and --version
+    from reranker import E2RankReranker, CrossEncoderReranker
+    from src.ragar_corag import RagarCorag
+
+    ragar_dir = config.RAGAR_DIR
+    madr_dir = config.MADR_DIR
+    if args.ragar_orig:
+        ragar_dir = config.RAGAR_ORIG_DIR
+        config.LOGGER.info("Using original RAGAR prompts.")
+    if args.madr_orig:
+        madr_dir = config.MADR_ORIG_DIR
+        config.LOGGER.info("Using original MADR prompts.")
+    prompt_files = get_prompt_files(ragar_dir, madr_dir)
+
+    reranker = None
+    if args.reranker:
+        try:
+            reranker = CrossEncoderReranker()
+        except (OSError, FileNotFoundError) as e:
+            print(f"ERROR: Model files not found or download failed: {e}")
+            reranker = None
+
+    mc = LlamaCppClient(prompt_files, think_mode_bool=args.think)
+    corag = RagarCorag(mc, args.debate_stop, args.debate_verdict, reranker=reranker)
+
+    if args.num_claims > 0:
+        config.LOGGER.info("Enabling benchmarking mode.")
+        benchmark(mc, corag, args)
+        exit(0)

--- a/main.py
+++ b/main.py
@@ -70,10 +70,10 @@ def parse_arguments():
                         help='Enable reranking after BM25 retrieval.',
                         action='store_true')
     parser.add_argument('--debate-stop',
-                        help='Refines the stop_check agent with MADR. Overrides -r.',
+                        help='Refines the stop_check agent with MADR.',
                         action='store_true')
     parser.add_argument('--debate-verdict',
-                        help='Refines the verdict agent with MADR. Overrides -r.',
+                        help='Refines the verdict agent with MADR.',
                         action='store_true')
     parser.add_argument('-l', '--log-trace',
                         help='Output a trace to the log file (define in config.py). Overrides --num-claims to 2.',

--- a/main.py
+++ b/main.py
@@ -1,11 +1,4 @@
 #!/usr/bin/env python3
-BANNER = """\
-    _/_/_/_/    _/_/    _/_/_/    _/        _/_/_/_/
-   _/        _/    _/  _/    _/  _/        _/
-  _/_/_/    _/_/_/_/  _/_/_/    _/        _/_/_/
- _/        _/    _/  _/    _/  _/        _/
-_/        _/    _/  _/_/_/    _/_/_/_/  _/_/_/_/"""
-VERSION = "v1.0.0"
 """
 Copyright:
 
@@ -29,17 +22,27 @@ from datasets import load_dataset, Dataset, concatenate_datasets
 from datetime import datetime
 from pathlib import Path
 from src import config
+from src import repl
 from src.model_clients import LlamaCppClient
 from src.utils import get_prompt_files, compute_metrics
 from tqdm import tqdm
+from types import ModuleType
+from typing import Optional
 import argparse
 import json
+import os
 import time
+
+readline: Optional[ModuleType]
+try:
+    import readline
+except ImportError:
+    readline = None
 
 class BannerVersion(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
-        print(BANNER)
-        print(f"version {VERSION}")
+        print(config.BANNER)
+        print(f"version {config.VERSION}")
         parser.exit()
 
 def parse_arguments():
@@ -179,3 +182,13 @@ if __name__ == "__main__":
         config.LOGGER.info("Enabling benchmarking mode.")
         benchmark(mc, corag, args)
         exit(0)
+
+    if readline and os.path.exists(config.REPL_HISTFILE):
+        readline.read_history_file(config.REPL_HISTFILE)
+
+    repl = repl.Repl(corag)
+    repl.interact(banner=config.BANNER, exitmsg="Goodbye.")
+
+    if readline:
+        readline.set_history_length(config.REPL_HISTFILE_SIZE)
+        readline.write_history_file(config.REPL_HISTFILE)

--- a/main.py
+++ b/main.py
@@ -33,12 +33,6 @@ import json
 import os
 import time
 
-readline: Optional[ModuleType]
-try:
-    import readline
-except ImportError:
-    readline = None
-
 class BannerVersion(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
         print(config.BANNER)
@@ -183,12 +177,5 @@ if __name__ == "__main__":
         benchmark(mc, corag, args)
         exit(0)
 
-    if readline and os.path.exists(config.REPL_HISTFILE):
-        readline.read_history_file(config.REPL_HISTFILE)
-
     repl = repl.Repl(corag)
     repl.interact(banner=config.BANNER, exitmsg="Goodbye.")
-
-    if readline:
-        readline.set_history_length(config.REPL_HISTFILE_SIZE)
-        readline.write_history_file(config.REPL_HISTFILE)

--- a/main.py
+++ b/main.py
@@ -1,4 +1,11 @@
 #!/usr/bin/env python3
+BANNER = """\
+    _/_/_/_/    _/_/    _/_/_/    _/        _/_/_/_/
+   _/        _/    _/  _/    _/  _/        _/
+  _/_/_/    _/_/_/_/  _/_/_/    _/        _/_/_/
+ _/        _/    _/  _/    _/  _/        _/
+_/        _/    _/  _/_/_/    _/_/_/_/  _/_/_/_/"""
+VERSION = "v1.0.0"
 """
 Copyright:
 
@@ -21,22 +28,29 @@ from collections import Counter
 from datasets import load_dataset, Dataset, concatenate_datasets
 from datetime import datetime
 from pathlib import Path
-from reranker import E2RankReranker, CrossEncoderReranker
 from src import config
 from src.model_clients import LlamaCppClient
-from src.ragar_corag import RagarCorag
 from src.utils import get_prompt_files, compute_metrics
 from tqdm import tqdm
 import argparse
 import json
 import time
 
+class BannerVersion(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        print(BANNER)
+        print(f"version {VERSION}")
+        parser.exit()
 
 def parse_arguments():
     parser = argparse.ArgumentParser(
         usage='%(prog)s [args] -- prog'
     )
 
+    parser.add_argument('-v', '--version',
+                        action=BannerVersion,
+                        nargs=0,
+                        help="show the version number")
     parser.add_argument('-t', '--think',
                         help='Whether the Qwen model should think before '
                         'answering. Affects runtime.',
@@ -88,6 +102,9 @@ def setup_fever(num_claims: int):
 
 if __name__ == "__main__":
     args = parse_arguments()
+    # load these later to enable fast --help and --version
+    from reranker import E2RankReranker, CrossEncoderReranker
+    from src.ragar_corag import RagarCorag
 
     ragar_dir = config.RAGAR_DIR
     madr_dir = config.MADR_DIR

--- a/main.py
+++ b/main.py
@@ -26,8 +26,6 @@ from src import repl
 from src.model_clients import LlamaCppClient
 from src.utils import get_prompt_files, compute_metrics
 from tqdm import tqdm
-from types import ModuleType
-from typing import Optional
 import argparse
 import json
 import os
@@ -101,7 +99,6 @@ def benchmark(mc, corag, args):
     fever_labels = {0: "REFUTES", 1: "SUPPORTS", 2: "NOT ENOUGH INFO", 3: "NONE"}
     fever_split = setup_fever(args.num_claims)
 
-    # Setup CoRAG system here
     # Run pipeline on claims
     golds = []
     outputs = []

--- a/src/config.py
+++ b/src/config.py
@@ -19,6 +19,14 @@ from pathlib import Path
 import os
 import logging
 
+BANNER = """\
+    _/_/_/_/    _/_/    _/_/_/    _/        _/_/_/_/
+   _/        _/    _/  _/    _/  _/        _/
+  _/_/_/    _/_/_/_/  _/_/_/    _/        _/_/_/
+ _/        _/    _/  _/    _/  _/        _/
+_/        _/    _/  _/_/_/    _/_/_/_/  _/_/_/_/"""
+VERSION = "v1.0.0"
+
 SCRIPT_DIR = Path(__file__).resolve().parent
 DATA_DIR = SCRIPT_DIR.parent / "data"
 LOGS_DIR = SCRIPT_DIR.parent / "logs"
@@ -28,6 +36,9 @@ INDEX_DIR = WIKI_DIR / "index"
 PAGES_DIR = WIKI_DIR / "wiki-pages"
 TRACE_PATH = LOGS_DIR / "trace.log"
 EVAL_OUT_FNAME_BASE = "metrics"
+
+REPL_HISTFILE = os.path.join(LOGS_DIR, 'repl.history')
+REPL_HISTFILE_SIZE = 1000
 
 CLAIMS_PATH = DATA_DIR / "fever-claims.json"
 QRELS_PATH = DATA_DIR / "fever-qrel.json"

--- a/src/config.py
+++ b/src/config.py
@@ -37,9 +37,6 @@ PAGES_DIR = WIKI_DIR / "wiki-pages"
 TRACE_PATH = LOGS_DIR / "trace.log"
 EVAL_OUT_FNAME_BASE = "metrics"
 
-REPL_HISTFILE = os.path.join(LOGS_DIR, 'repl.history')
-REPL_HISTFILE_SIZE = 1000
-
 CLAIMS_PATH = DATA_DIR / "fever-claims.json"
 QRELS_PATH = DATA_DIR / "fever-qrel.json"
 RANKLISTS_PATH = DATA_DIR / "fever-ranklist.json"

--- a/src/repl.py
+++ b/src/repl.py
@@ -37,14 +37,15 @@ class Repl(code.InteractiveConsole):
             return False
         out = True
         if len(source) > 0:
+            start = time.time()
             out = self.corag.run(source)
-        return out
+        return out, time.time() - start
 
-    def respond(self, out):
+    def respond(self, out, time):
         claim = out["claim"]
         verdict = out["verdict_raw"]
         verdict_bool = out["verdict"]
-        print(f"\nWe considered the claim: {claim}")
+        print(f"\nWe spent {round(time, 2)} seconds considering the claim: {claim}.")
         print(f"\nThe questions we posed and answered were:")
         for e in out["qa_pairs"]:
             print(f"\tQuestion: {e[0]}\n\t\t{e[1]}")
@@ -62,7 +63,7 @@ class Repl(code.InteractiveConsole):
                 self.loading_thread = threading.Thread(target=self.obnoxious_load)
                 self.loading_thread.start()
 
-                out = self.runsource(source)
+                out, time = self.runsource(source)
 
                 self.loading = False
                 self.loading_thread.join()
@@ -70,7 +71,7 @@ class Repl(code.InteractiveConsole):
                 if not out:
                     break
                 if isinstance(out, dict):
-                    self.respond(out)
+                    self.respond(out, time)
             except EOFError:
                 print(exitmsg)
                 break

--- a/src/repl.py
+++ b/src/repl.py
@@ -36,8 +36,8 @@ class Repl(code.InteractiveConsole):
         if source.strip().lower() in ["quit", "exit", "bye"]:
             return False
         out = True
+        start = time.time()
         if len(source) > 0:
-            start = time.time()
             out = self.corag.run(source)
         return out, time.time() - start
 
@@ -72,6 +72,8 @@ class Repl(code.InteractiveConsole):
                     break
                 if isinstance(out, dict):
                     self.respond(out, time)
+                else:
+                    print()
             except EOFError:
                 print(exitmsg)
                 break

--- a/src/repl.py
+++ b/src/repl.py
@@ -63,15 +63,15 @@ class Repl(code.InteractiveConsole):
                 self.loading_thread = threading.Thread(target=self.obnoxious_load)
                 self.loading_thread.start()
 
-                out, time = self.runsource(source)
+                result = self.runsource(source)
 
                 self.loading = False
                 self.loading_thread.join()
 
-                if not out:
+                if not result:
                     break
-                if isinstance(out, dict):
-                    self.respond(out, time)
+                if isinstance(result[0], dict):
+                    self.respond(*result)
                 else:
                     print()
             except EOFError:

--- a/src/repl.py
+++ b/src/repl.py
@@ -1,0 +1,79 @@
+"""
+Copyright:
+
+  Copyright © 2025 bdunahu
+
+  You should have received a copy of the MIT license along with this file.
+  If not, see https://mit-license.org/
+
+Commentary:
+
+  This file includes a small interactive REPL.
+
+Code:
+"""
+
+import code
+import threading
+import time
+import sys
+
+class Repl(code.InteractiveConsole):
+    def __init__(self, corag):
+        super().__init__()
+        self.corag = corag
+        self.verdict_keys = ["false", "true", "inconclusive"]
+        self.loading_thread = None
+        self.loading = False
+
+    def obnoxious_load(self):
+        while self.loading:
+            for f in ["|", "/", "-", "\\"]:
+                print(f"\rThinking...{f}", end="", flush=True)
+                time.sleep(0.2)
+
+    def runsource(self, source, filename="<input>", symbol="single"):
+        if source.strip().lower() in ["quit", "exit", "bye"]:
+            return False
+        out = True
+        if len(source) > 0:
+            out = self.corag.run(source)
+        return out
+
+    def respond(self, out):
+        claim = out["claim"]
+        verdict = out["verdict_raw"]
+        verdict_bool = out["verdict"]
+        print(f"\nWe considered the claim: {claim}")
+        print(f"\nThe questions we posed and answered were:")
+        for e in out["qa_pairs"]:
+            print(f"\tQuestion: {e[0]}\n\t\t{e[1]}")
+        print()
+        print(f"Based on this, we logically conclude:\n\t{verdict}")
+        print(f"Our final answer: {self.verdict_keys[verdict_bool]}\n\n")
+
+    def interact(self, banner=None, exitmsg=None):
+        if banner:
+            print(banner)
+        while True:
+            try:
+                source = input('Say: ')
+                self.loading = True
+                self.loading_thread = threading.Thread(target=self.obnoxious_load)
+                self.loading_thread.start()
+
+                out = self.runsource(source)
+
+                self.loading = False
+                self.loading_thread.join()
+
+                if not out:
+                    break
+                if isinstance(out, dict):
+                    self.respond(out)
+            except EOFError:
+                print(exitmsg)
+                break
+            except KeyboardInterrupt:
+                print(exitmsg)
+                break


### PR DESCRIPTION
You now mush specify `--num-claims` to get the old behavior.

Note I can't report MADR because we don't return those results from corag.run, and it would require a lot of changes to integrate that.

Since the demo is only a few seconds, this seems good enough.